### PR TITLE
Added decline and cancel actions to retrieve the

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -1,5 +1,5 @@
 class MeetingsController < ApplicationController
-  before_action :set_meeting, only: [ :show, :accept ]
+  before_action :set_meeting, only: [ :show, :accept, :decline, :cancel ]
   before_action :set_lecture, only: [ :create ]
 
   def index
@@ -28,10 +28,34 @@ class MeetingsController < ApplicationController
   end
 
   def accept
+    authorize @meeting
+
     if @meeting.update(status: "accepted")
-      redirect_to dashboard_path, notice: 'Meeting request accepted!'
+      redirect_to dashboard_path, notice: "Meeting request accepted!"
     else
-      redirect_to dashboard_path, alert: 'Something went wrong.'
+      redirect_to dashboard_path, alert: "Something went wrong."
+    end
+  end
+
+  def decline
+    authorize @meeting
+
+    if @meeting.update(status: "declined")
+      redirect_to dashboard_path, notice: "Meeting request declined!"
+    else
+      redirect_to dashboard_path, alert: "Something went wrong."
+    end
+
+  end
+
+  def cancel
+    authorize @meeting
+
+    if @meeting.requester == current_user && @meeting.status == "pending"
+      @meeting.destroy
+      redirect_to dashboard_path, notice: "Meeting request canceled."
+    else
+      redirect_to dashboard_path, alert: 'You can only cancel your own pending requests.'
     end
   end
 

--- a/app/policies/meeting_policy.rb
+++ b/app/policies/meeting_policy.rb
@@ -22,6 +22,14 @@ class MeetingPolicy < ApplicationPolicy
     user == record.requester || user == record.receiver
   end
 
+  def accept?
+    record.receiver == user
+  end
+
+  def decline?
+    record.requester == user
+  end
+
   def cancel?
     record.requester == user && record.status == "pending"
   end

--- a/app/policies/meeting_policy.rb
+++ b/app/policies/meeting_policy.rb
@@ -21,4 +21,8 @@ class MeetingPolicy < ApplicationPolicy
     # For example, check if the user is either the requester or the receiver
     user == record.requester || user == record.receiver
   end
+
+  def cancel?
+    record.requester == user && record.status == "pending"
+  end
 end

--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -7,6 +7,15 @@
     <p><strong>Lecture:</strong> <%= @meeting.lecture.title %></p>
     <p><strong>Start time:</strong> <%= @meeting.start_time.strftime("%B %d, %Y %H:%M") %></p>
     <p><strong>End time:</strong> <%= @meeting.end_time.strftime("%H:%M") %></p>
+
+    <% if @meeting.status == "pending" && current_user == @meeting.receiver %>
+      <%= link_to 'Accept', accept_meeting_path(@meeting), method: :patch, class: 'btn btn-success' %>
+      <%= link_to 'Decline', decline_meeting_path(@meeting), method: :patch, class: 'btn btn-danger' %>
+    <% elsif @meeting.status == "pending" && current_user == @meeting.requester %>
+      <%# <%= link_to 'Cancel Request', cancel_meeting_path(@meeting), method: :delete, class: 'btn btn-warning' %>
+      <%= link_to 'Cancel Request', cancel_meeting_path(@meeting), data: { turbo_method: :delete, turbo_confirm: "Are you sure?"  }, class: 'btn btn-warning' %>
+    <% end %>
+
     <%= link_to 'Back to Meetings', dashboard_path, class: 'btn btn-secondary' %>
   </div>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   get "profile/:id/edit", to: "users#edit", as: "edit_user_profile"
   patch "profile/:id", to: "users#update"
-  
+
   resources :chapters, only: [ :index, :show ]
 
   resources :lectures, only: [ :show ] do
@@ -31,8 +31,9 @@ Rails.application.routes.draw do
 
   resources :meetings, only: [ :show ] do
     member do
-      patch :accepted
-      patch :declined
+      patch :accept
+      patch :decline
+      delete :cancel
     end
   end
 end


### PR DESCRIPTION
meeting by ID
Added decline and cancel actions to handle meeting status updates. Authorized the actions for the current user Added Pundit authorization to allow the current
user to cancel the meeting they created
Reviewed the meeting show view to include accept,
decline, and cancel buttons. Only the cancel button is visible to the current user
Updated routes to handle the decline action with a PATCH method and remove the cancel action as DELETE